### PR TITLE
Add support for new pm25 sensor readings

### DIFF
--- a/ambient.go
+++ b/ambient.go
@@ -62,7 +62,7 @@ type Record struct {
 	Humidityin     int
 	LastRain       time.Time
 	Maxdailygust   float64
-	Pm25           float64
+	Pm25           int
 	Pm25_24h       float64
 	Relay1         int
 	Relay2         int

--- a/ambient.go
+++ b/ambient.go
@@ -62,6 +62,8 @@ type Record struct {
 	Humidityin     int
 	LastRain       time.Time
 	Maxdailygust   float64
+	Pm25           float64
+	Pm25_24h       float64
 	Relay1         int
 	Relay2         int
 	Relay3         int


### PR DESCRIPTION
I'm not sure if your accepting pull requests.

This adds support for:
> pm25 - PM2.5 Air Quality, Int, µg/m^3
> pm25_24h - PM2.5 Air Quality 24 hour average, Float, µg/m^3

I'm happy to tweak or modify this PR in any way if you'd like.